### PR TITLE
Update MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,4 @@ include README.rst
 include CHANGES.rst
 include COPYING.LGPLv3
 include multiselectfield/locale/*/LC_MESSAGES/*.*
-prune   example/
+prune   example


### PR DESCRIPTION
Windows users can't install because of the error raised here:

```
raise ValueError, "path '%s' cannot end with '/'" % pathname
```

issue occurs when os.sep != '/'

Other django projects already updated it
