### PR TITLE
Specifying default value in South fixed

### DIFF
--- a/multiselectfield/db/fields.py
+++ b/multiselectfield/db/fields.py
@@ -104,6 +104,11 @@ class MultiSelectField(models.CharField):
     def get_prep_value(self, value):
         return '' if value is None else ",".join(value)
 
+    def get_db_prep_value(self, value, connection, prepared=False):
+        if not prepared and not isinstance(value, str) and not isinstance(value, unicode):
+            value = self.get_prep_value(value)
+        return value
+
     def to_python(self, value):
         if value:
             return value if isinstance(value, list) else value.split(',')

--- a/multiselectfield/db/fields.py
+++ b/multiselectfield/db/fields.py
@@ -105,7 +105,7 @@ class MultiSelectField(models.CharField):
         return '' if value is None else ",".join(value)
 
     def get_db_prep_value(self, value, connection, prepared=False):
-        if not prepared and not isinstance(value, str) and not isinstance(value, unicode):
+        if not prepared and not isinstance(value, string_type):
             value = self.get_prep_value(value)
         return value
 


### PR DESCRIPTION
Specifying **default** value for field in South's migration did not work properly. With this fix it is now possible to define **default** value using Python 2 like this:

    default=u'item1,item2,item3'

And using Python 3:

    default='item1,item2,item3'