### PR TITLE
Support for named groups in choices

### DIFF
--- a/multiselectfield/db/fields.py
+++ b/multiselectfield/db/fields.py
@@ -65,9 +65,15 @@ class MultiSelectField(models.CharField):
         return self.get_choices(include_blank=False)
 
     def get_choices_selected(self, arr_choices):
+        named_groups = arr_choices and isinstance(arr_choices[0][1], (list, tuple))
         choices_selected = []
-        for choice_selected in arr_choices:
-            choices_selected.append(string_type(choice_selected[0]))
+        if named_groups:
+            for choice_group_selected in arr_choices:
+                for choice_selected in choice_group_selected[1]:
+                    choices_selected.append(string_type(choice_selected[0]))
+        else:
+            for choice_selected in arr_choices:
+                choices_selected.append(string_type(choice_selected[0]))
         return choices_selected
 
     def value_to_string(self, obj):


### PR DESCRIPTION
This PR fixes an issue where named groups in `choices` would cause validation errors.

For example, this now works:
```python
PROVINCES = (
    ("AB", "Alberta"),
    ("BC", "British Columbia"),
    # ... snip ...
)
STATES = (
    ("AL", "Alabama"),
    ("AK", "Alaska"),
    ("AZ", "Arizona"),
    # ... snip ...
)
PROVINCES_AND_STATES = (
    ("Canada - Provinces", PROVINCES),
    ("USA - States", STATES),
)

class Address(models.Model):
    # ... snip ...
    province_state = MultiSelectField(
        _('Province or State'), max_length=2, choices=PROVINCES_AND_STATES)
    # ... snip ...
```