### PR TITLE
to_python returns list instead of None

### DIFF
--- a/multiselectfield/db/fields.py
+++ b/multiselectfield/db/fields.py
@@ -107,6 +107,7 @@ class MultiSelectField(models.CharField):
     def to_python(self, value):
         if value:
             return value if isinstance(value, list) else value.split(',')
+        return []
 
     def contribute_to_class(self, cls, name):
         super(MultiSelectField, self).contribute_to_class(cls, name)

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ def read(*rnames):
 
 setup(
     name="django-multiselectfield",
-    version="0.1.3",
+    version="0.1.4",
     author="Pablo Martin",
     author_email="goinnn@gmail.com",
     description="Django multiple select field",


### PR DESCRIPTION
When using a MultiSelectFieldi it's easier to simply issue a "item in field" than to test for None first ("field is not None and item in field").

In the snippet that originated django-multiselectfield, an empty string is returned. But since MultiSelectFields are "multi", a list seems the way to go.