### PR TITLE
fix for versions > 1.8

### DIFF
--- a/example/example/settings.py
+++ b/example/example/settings.py
@@ -153,14 +153,14 @@ else:
             'BACKEND': 'django.template.backends.django.DjangoTemplates',
             'OPTIONS': {
                 'context_processors': [
-                'django.contrib.auth.context_processors.auth',
-                'django.template.context_processors.debug',
-                'django.template.context_processors.i18n',
-                'django.template.context_processors.media',
-                'django.template.context_processors.request',
-                'django.template.context_processors.static',
-                'django.template.context_processors.tz',
-                'django.contrib.messages.context_processors.messages',
+                    'django.contrib.auth.context_processors.auth',
+                    'django.template.context_processors.debug',
+                    'django.template.context_processors.i18n',
+                    'django.template.context_processors.media',
+                    'django.template.context_processors.request',
+                    'django.template.context_processors.static',
+                    'django.template.context_processors.tz',
+                    'django.contrib.messages.context_processors.messages',
                 ],
                 'debug': DEBUG,
                 'loaders': [

--- a/example/example/settings.py
+++ b/example/example/settings.py
@@ -153,14 +153,14 @@ else:
             'BACKEND': 'django.template.backends.django.DjangoTemplates',
             'OPTIONS': {
                 'context_processors': [
-                    'django.contrib.auth.context_processors.auth',
-                    'django.core.context_processors.debug',
-                    'django.core.context_processors.i18n',
-                    'django.core.context_processors.media',
-                    'django.core.context_processors.request',
-                    'django.core.context_processors.tz',
-                    'django.core.context_processors.static',
-                    'django.contrib.messages.context_processors.messages',
+                'django.contrib.auth.context_processors.auth',
+                'django.template.context_processors.debug',
+                'django.template.context_processors.i18n',
+                'django.template.context_processors.media',
+                'django.template.context_processors.request',
+                'django.template.context_processors.static',
+                'django.template.context_processors.tz',
+                'django.contrib.messages.context_processors.messages',
                 ],
                 'debug': DEBUG,
                 'loaders': [


### PR DESCRIPTION
Throws `Import Error: No module named context_processors` when cloning example project