### PR TITLE
(bugfix) Migrations crash due to bytestrings in python 3

### DIFF
--- a/multiselectfield/db/fields.py
+++ b/multiselectfield/db/fields.py
@@ -133,6 +133,8 @@ class MultiSelectField(models.CharField):
         return MultiSelectFormField(**defaults)
 
     def get_prep_value(self, value):
+        if isinstance(value, bytes):
+            return value.decode('utf-8')
         return '' if value is None else ",".join(value)
 
     def get_db_prep_value(self, value, connection, prepared=False):


### PR DESCRIPTION
If the passed value is a bytestring, decode it to a utf-8 string.

This occurs when running migrations that alter the field, django migrations pass a bytestring value to get_prep_value which crashes because it tries to call ,.join() on a bytestring. Previously the assumption was that if the value wasn't a string it was a list, but it could also be a bytestring so we handle that case now.