### PR TITLE
Fix bug: when int in choices will get 'TypeError: sequence item int_v…

### DIFF
--- a/multiselectfield/db/fields.py
+++ b/multiselectfield/db/fields.py
@@ -133,7 +133,7 @@ class MultiSelectField(models.CharField):
         return MultiSelectFormField(**defaults)
 
     def get_prep_value(self, value):
-        return '' if value is None else ",".join(value)
+        return '' if value is None else ','.join([str(x) for x in value])
 
     def get_db_prep_value(self, value, connection, prepared=False):
         if not prepared and not isinstance(value, string_type):


### PR DESCRIPTION
Fix bug: when int in choices will get ` 'TypeError: sequence item int_value: expected str instance, int found'`,
change value item form int to str in method `get_prep_value`