### PR TITLE
Update lazy translation import

### DIFF
--- a/multiselectfield/validators.py
+++ b/multiselectfield/validators.py
@@ -16,7 +16,7 @@
 
 
 from django.core import validators
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class MaxValueMultiFieldValidator(validators.MaxLengthValidator):


### PR DESCRIPTION
`ugettext_lazy` is deprecated as of Django 3.0 (to be removed in Django 4.0)