### PR TITLE
Return MSFList, not plain list, from form field

### DIFF
--- a/multiselectfield/db/fields.py
+++ b/multiselectfield/db/fields.py
@@ -23,7 +23,7 @@ from django.utils.text import capfirst
 from django.core import exceptions
 
 from ..forms.fields import MultiSelectFormField, MinChoicesValidator, MaxChoicesValidator
-from ..utils import get_max_length
+from ..utils import MSFList, get_max_length
 from ..validators import MaxValueMultiFieldValidator
 
 if sys.version_info < (3,):
@@ -44,21 +44,6 @@ def add_metaclass(metaclass):
             orig_vars.pop(slots_var)
         return metaclass(cls.__name__, cls.__bases__, orig_vars)
     return wrapper
-
-
-class MSFList(list):
-
-    def __init__(self, choices, *args, **kwargs):
-        self.choices = choices
-        super(MSFList, self).__init__(*args, **kwargs)
-
-    def __str__(msgl):
-        msg_list = [msgl.choices.get(int(i)) if i.isdigit() else msgl.choices.get(i) for i in msgl]
-        return u', '.join([string_type(s) for s in msg_list])
-
-    if sys.version_info < (3,):
-        def __unicode__(self, msgl):
-            return self.__str__(msgl)
 
 
 class MultiSelectField(models.CharField):
@@ -130,6 +115,7 @@ class MultiSelectField(models.CharField):
                     'label': capfirst(self.verbose_name),
                     'help_text': self.help_text,
                     'choices': self.choices,
+                    'flat_choices': self.flatchoices,
                     'max_length': self.max_length,
                     'max_choices': self.max_choices}
         if self.has_default():

--- a/multiselectfield/forms/fields.py
+++ b/multiselectfield/forms/fields.py
@@ -16,7 +16,7 @@
 
 from django import forms
 
-from ..utils import get_max_length
+from ..utils import MSFList, get_max_length
 from ..validators import MaxValueMultiFieldValidator, MinChoicesValidator, MaxChoicesValidator
 
 
@@ -27,6 +27,7 @@ class MultiSelectFormField(forms.MultipleChoiceField):
         self.min_choices = kwargs.pop('min_choices', None)
         self.max_choices = kwargs.pop('max_choices', None)
         self.max_length = kwargs.pop('max_length', None)
+        self.flat_choices = kwargs.pop('flat_choices')
         super(MultiSelectFormField, self).__init__(*args, **kwargs)
         self.max_length = get_max_length(self.choices, self.max_length)
         self.validators.append(MaxValueMultiFieldValidator(self.max_length))
@@ -34,3 +35,6 @@ class MultiSelectFormField(forms.MultipleChoiceField):
             self.validators.append(MaxChoicesValidator(self.max_choices))
         if self.min_choices is not None:
             self.validators.append(MinChoicesValidator(self.min_choices))
+
+    def to_python(self, value):
+        return MSFList(dict(self.flat_choices), super(MultiSelectFormField, self).to_python(value))

--- a/multiselectfield/utils.py
+++ b/multiselectfield/utils.py
@@ -25,6 +25,21 @@ else:
     string_type = string
 
 
+class MSFList(list):
+
+    def __init__(self, choices, *args, **kwargs):
+        self.choices = choices
+        super(MSFList, self).__init__(*args, **kwargs)
+
+    def __str__(msgl):
+        msg_list = [msgl.choices.get(int(i)) if i.isdigit() else msgl.choices.get(i) for i in msgl]
+        return u', '.join([string_type(s) for s in msg_list])
+
+    if sys.version_info < (3,):
+        def __unicode__(self, msgl):
+            return self.__str__(msgl)
+
+
 def get_max_length(choices, max_length, default=200):
     if max_length is None:
         if choices:


### PR DESCRIPTION
This pull request fixes `MultiSelectFormField` to return the proper type - `MSFList` instead of `list`.

Consider this model:
```python
from django.db import models
from multiselectfield import MultiSelectField


class TestModel(models.Model):
    msf_field = MultiSelectField(choices=[("a", "Value a"), ("b", "Value b")])

    def save(self, *args, **kwargs):
        if self.id:
            # an edit
            old = self.__class__.objects.get(pk=self.pk)
            print(f"{type(self.msf_field)=} | {type(old.msf_field)=}")
            print(f"{repr(self.msf_field)=} | {repr(old.msf_field)=}")
            print(f"{str(self.msf_field)=} | {str(old.msf_field)=}")
            assert self.msf_field == old.msf_field, "unequal"
            assert str(self.msf_field) == str(old.msf_field), "string representation unequal"  # <- this fails

        super().save(*args, **kwargs)
```
Whenever a user edits an instance of this model through the admin (default ModelAdmin is sufficient for testing) without editing the multiselect field, the second assertion will fail.

While no sane person will actually perform such assertions in model `save`, audit-logging libraries (like https://github.com/jazzband/django-auditlog) may report false changes based on unequal string representation.