### PR TITLE
Add 'min_choices' to defaults in 'formfield' function

### DIFF
--- a/multiselectfield/db/fields.py
+++ b/multiselectfield/db/fields.py
@@ -117,6 +117,7 @@ class MultiSelectField(models.CharField):
                     'choices': self.choices,
                     'flat_choices': self.flatchoices,
                     'max_length': self.max_length,
+                    'min_choices': self.min_choices,
                     'max_choices': self.max_choices}
         if self.has_default():
             defaults['initial'] = self.get_default()


### PR DESCRIPTION
Apparently, this is a bug. I didn't find a pull request for correction.