### PR TITLE
Bump workflow actions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -20,9 +20,9 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.py }}
 


### PR DESCRIPTION
Updates both `actions/checkout` and `actions/setup-python` to remove warnings about deprecated Node.js in workflow logs.