### PR TITLE
update tox.ini, use tox testing in GitHub actions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,10 +13,12 @@ jobs:
       # and https://docs.djangoproject.com/en/4.2/faq/install/#what-python-version-can-i-use-with-django
       matrix:
         include:
-          - { dj: "4.2.*", py: "3.8" }
-          - { dj: "4.2.*", py: "3.12" }
-          - { dj: "5.0.*", py: "3.10" }
-          - { dj: "5.0.*", py: "3.12" }
+          - { django: "4.2", python: "3.8" }
+          - { django: "4.2", python: "3.12" }
+          - { django: "5.0", python: "3.10" }
+          - { django: "5.0", python: "3.12" }
+          - { django: "5.1", python: "3.10" }
+          - { django: "5.1", python: "3.12" }
       fail-fast: false
 
     steps:
@@ -24,21 +26,20 @@ jobs:
 
     - uses: actions/setup-python@v4
       with:
-        python-version: ${{ matrix.py }}
+        python-version: ${{ matrix.python }}
 
     - name: Install test deps
-      run: pip install flake8 coverage
+      run: pip install flake8 tox
 
-    - name: Install django
-      run: pip install django==${{ matrix.dj }}
-        
     - name: Install library
       run: pip install -e .
 
-    # Disabled for now, at some point we'll use black instead
-    # - name: Lint
-    #   run: flake8 --ignore=E501
+    - name: Lint
+      run: flake8 --ignore=E501
 
     - name: Run tests
       working-directory: example
-      run: python -m coverage run manage.py test
+      run: |
+        PYTHON_VERSION=`echo ${{ matrix.python }} | sed 's/\.//'`
+        DJANGO_VERSION=`echo ${{ matrix.django }} | sed 's/\.//'`
+        tox -e python${PYTHON_VERSION}-django${DJANGO_VERSION}

--- a/example/app/test_msf.py
+++ b/example/app/test_msf.py
@@ -22,6 +22,7 @@ from multiselectfield.utils import get_max_length
 
 from .models import Book, PROVINCES, STATES, PROVINCES_AND_STATES, ONE, TWO
 
+
 class MultiSelectTestCase(TestCase):
 
     fixtures = ['app_data.json']

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,10 @@
 [tox]
-envlist = py{27,34,35,36}-dj{14,15,16,16,17,18,19,110,111},py{34,35,36,37}-dj{14,15,16,16,17,18,19,110,111,20},py{35,36,37}-dj{21,22},py{38}-dj{22},py{36,37,38}-dj{30}
+envlist =
+    python{36,37,38,39,310}-django32,
+    python{38,39,310}-django40,
+    python{38,39,310,311}-django41,
+    python{38,39,310,311,312}-django42,
+    python{310,311,312}-django50
 
 [testenv]
 usedevelop = True
@@ -11,228 +16,14 @@ commands =
     python {envbindir}/coverage run -p example/run_tests.py example.settings_no_debug
 install_command =
     pip install {opts} {packages}
-
-[testenv:py27-dj14]
-basepython = python2.7
 deps =
-    django==1.4.22
-    pillow==1.7.8
-    PyYAML==3.10
-    coveralls==0.3
+    coveralls
     flake8
-
-[testenv:py27-dj15]
-basepython = python2.7
-deps =
-    django==1.5.12
-    pillow==1.7.8
-    PyYAML==3.10
-    coveralls==0.3
-    flake8
-
-[testenv:py27-dj16]
-basepython = python2.7
-deps =
-    django==1.6.11
-    pillow==1.7.8
-    PyYAML==3.10
-    coveralls==0.3
-    flake8
-
-[testenv:py27-dj17]
-basepython = python2.7
-deps =
-    django==1.7.11
-    pillow==1.7.8
-    PyYAML==3.10
-    coveralls==0.3
-    flake8
-
-[testenv:py27-dj18]
-basepython = python2.7
-deps =
-    django==1.8.17
-    pillow==1.7.8
-    PyYAML==3.10
-    coveralls==0.3
-    flake8
-
-[testenv:py27-dj19]
-basepython = python2.7
-deps =
-    django==1.9.12
-    pillow==1.7.8
-    PyYAML==3.10
-    coveralls==0.3
-    flake8
-
-[testenv:py27-dj110]
-basepython = python2.7
-deps =
-    django==1.10.4
-    pillow==1.7.8
-    PyYAML==3.10
-    coveralls==0.3
-    flake8
-
-[testenv:py27-dj111]
-basepython = python2.7
-deps =
-    django==1.11.15
-    pillow==1.7.8
-    PyYAML==3.13
-    coveralls==0.3
-    flake8
-
-[testenv:py34-dj111]
-basepython = python3.4
-deps =
-    django==1.11.15
-    pillow==2.1.0
-    PyYAML==3.13
-    coveralls==0.3
-    flake8
-
-[testenv:py34-dj20]
-basepython = python3.4
-deps =
-    django==2.0.8
-    pillow==2.1.0
-    PyYAML==3.13
-    coveralls==0.3
-    flake8
-
-[testenv:py35-dj111]
-basepython = python3.5
-deps =
-    django==1.11.15
-    pillow==2.1.0
-    PyYAML==3.13
-    coveralls==0.3
-    flake8
-
-[testenv:py35-dj20]
-basepython = python3.5
-deps =
-    django==2.0.8
-    pillow==2.1.0
-    PyYAML==3.13
-    coveralls==0.3
-    flake8
-
-[testenv:py35-dj21]
-basepython = python3.5
-deps =
-    django==2.1.1
-    pillow==2.1.0
-    PyYAML==3.13
-    coveralls==0.3
-    flake8
-
-[testenv:py35-dj22]
-basepython = python3.5
-deps =
-    django==2.2.1
-    pillow==2.1.0
-    PyYAML==3.13
-    coveralls==0.3
-    flake8
-
-[testenv:py36-dj111]
-basepython = python3.6
-deps =
-    django==1.11.15
-    pillow==2.1.0
-    PyYAML==3.13
-    coveralls==0.3
-    flake8
-
-[testenv:py36-dj20]
-basepython = python3.6
-deps =
-    django==2.0.8
-    pillow==2.1.0
-    PyYAML==3.13
-    coveralls==0.3
-    flake8
-
-[testenv:py36-dj21]
-basepython = python3.6
-deps =
-    django==2.1.1
-    pillow==2.1.0
-    PyYAML==3.13
-    coveralls==0.3
-    flake8
-
-[testenv:py36-dj22]
-basepython = python3.6
-deps =
-    django==2.2.1
-    pillow==2.1.0
-    PyYAML==3.13
-    coveralls==0.3
-    flake8
-
-[testenv:py37-dj20]
-basepython = python3.7
-deps =
-    django==2.0.8
-    pillow==2.1.0
-    PyYAML==3.13
-    coveralls==0.3
-    flake8
-
-[testenv:py37-dj21]
-basepython = python3.7
-deps =
-    django==2.1.1
-    pillow==2.1.0
-    PyYAML==3.13
-    coveralls==0.3
-    flake8
-
-[testenv:py37-dj22]
-basepython = python3.7
-deps =
-    django==2.2.1
-    pillow==2.1.0
-    PyYAML==3.13
-    coveralls==0.3
-    flake8
-
-[testenv:py38-dj22]
-basepython = python3.8
-deps =
-    django==2.2.1
-    pillow==2.1.0
-    PyYAML==3.13
-    coveralls==0.3
-    flake8
-
-[testenv:py36-dj30]
-basepython = python3.6
-deps =
-    django==3.0
-    pillow==2.1.0
-    PyYAML==3.13
-    coveralls==0.3
-    flake8
-
-[testenv:py37-dj30]
-basepython = python3.6
-deps =
-    django==3.0
-    pillow==2.1.0
-    PyYAML==3.13
-    coveralls==0.3
-    flake8
-
-[testenv:py38-dj30]
-basepython = python3.8
-deps =
-    django==3.0
-    pillow==2.1.0
-    PyYAML==3.13
-    coveralls==0.3
-    flake8
+    pillow
+    PyYAML
+    django32: django~=3.2
+    django40: django~=4.0
+    django41: django~=4.1
+    django42: django~=4.2
+    django50: django~=5.0
+    django51: django>=5.1a1,<5.2


### PR DESCRIPTION
- The `tox.ini` file has been rewritten (updated, shortened, fixed)
- The TOX testing is used for GitHub tests. I think it will help to keep the `tox.ini` up to date and reduce code duplication between `test.yaml` and `tox.ini`.
- I added the 5.1 (pre-release) to the testing matrix to ensure the upcoming version will be supported
- flake8 testing is re-enabled and fixed. It could be compatible with `black` testing with correct settings, so I think we can have both.

All tests are passing on my repository: https://github.com/PetrDlouhy/django-multiselectfield/actions/runs/9300560098
There is no need to pull this before making a new release since there is no change in the working code.