### PR TITLE
Replace http:// with https:// where relevant and fix a doc link

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -132,4 +132,4 @@ Thanks to:
 0.0.1 (2012-09-27)
 ------------------
 
-* Initial version from the next `snippet <http://djangosnippets.org/snippets/1200/>`_
+* Initial version from the next `snippet <https://djangosnippets.org/snippets/1200/>`_

--- a/COPYING.LGPLv3
+++ b/COPYING.LGPLv3
@@ -1,7 +1,7 @@
      GNU LESSER GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 

--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ django-multiselectfield
 
 A new model field and form field. With this you can get a multiple select from a choices. Stores to the database as a CharField of comma-separated values.
 
-This egg is inspired by this `snippet <http://djangosnippets.org/snippets/1200/>`_.
+This egg is inspired by this `snippet <https://djangosnippets.org/snippets/1200/>`_.
 
 Supported Python versions: 2.7, 3.4+
 

--- a/example/app/admin.py
+++ b/example/app/admin.py
@@ -12,7 +12,7 @@
 # GNU Lesser General Public License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public License
-# along with this software.  If not, see <http://www.gnu.org/licenses/>.
+# along with this software.  If not, see <https://www.gnu.org/licenses/>.
 
 from django.contrib import admin
 

--- a/example/app/models.py
+++ b/example/app/models.py
@@ -12,7 +12,7 @@
 # GNU Lesser General Public License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public License
-# along with this software.  If not, see <http://www.gnu.org/licenses/>.
+# along with this software.  If not, see <https://www.gnu.org/licenses/>.
 
 from django.db import models
 from django.utils.translation import gettext as _

--- a/example/app/test_msf.py
+++ b/example/app/test_msf.py
@@ -12,7 +12,7 @@
 # GNU Lesser General Public License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public License
-# along with this software.  If not, see <http://www.gnu.org/licenses/>.
+# along with this software.  If not, see <https://www.gnu.org/licenses/>.
 
 from django.core.exceptions import ValidationError
 from django.forms.models import modelform_factory

--- a/example/app/urls.py
+++ b/example/app/urls.py
@@ -12,7 +12,7 @@
 # GNU Lesser General Public License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public License
-# along with this software.  If not, see <http://www.gnu.org/licenses/>.
+# along with this software.  If not, see <https://www.gnu.org/licenses/>.
 
 from django.urls import path
 

--- a/example/app/views.py
+++ b/example/app/views.py
@@ -12,7 +12,7 @@
 # GNU Lesser General Public License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public License
-# along with this software.  If not, see <http://www.gnu.org/licenses/>.
+# along with this software.  If not, see <https://www.gnu.org/licenses/>.
 
 from django import VERSION
 from django.conf import settings

--- a/example/example/settings.py
+++ b/example/example/settings.py
@@ -12,7 +12,7 @@
 # GNU Lesser General Public License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public License
-# along with this programe.  If not, see <http://www.gnu.org/licenses/>.
+# along with this programe.  If not, see <https://www.gnu.org/licenses/>.
 
 # Django settings for example project.
 import os
@@ -43,11 +43,11 @@ DATABASES = {
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 # Hosts/domain names that are valid for this site; required if DEBUG is False
-# See https://docs.djangoproject.com/en/1.5/ref/settings/#allowed-hosts
+# See https://docs.djangoproject.com/en/5.0/ref/settings/#allowed-hosts
 ALLOWED_HOSTS = ['localhost']
 
 # Local time zone for this installation. Choices can be found here:
-# http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
+# https://en.wikipedia.org/wiki/List_of_tz_zones_by_name
 # although not all choices may be available on all operating systems.
 # In a Windows environment this must be set to your system time zone.
 TIME_ZONE = 'America/Chicago'
@@ -75,7 +75,7 @@ MEDIA_ROOT = path.join(BASE_DIR, 'media')
 
 # URL that handles the media served from MEDIA_ROOT. Make sure to use a
 # trailing slash.
-# Examples: "http://example.com/media/", "http://media.example.com/"
+# Examples: "https://example.com/media/", "https://media.example.com/"
 MEDIA_URL = '/media/'
 
 # Absolute path to the directory static files should be collected to.
@@ -85,7 +85,7 @@ MEDIA_URL = '/media/'
 STATIC_ROOT = path.join(BASE_DIR, 'static')
 
 # URL prefix for static files.
-# Example: "http://example.com/static/", "http://static.example.com/"
+# Example: "https://example.com/static/", "https://static.example.com/"
 STATIC_URL = '/static/'
 
 # Additional locations of static files
@@ -180,7 +180,7 @@ SESSION_SERIALIZER = 'django.contrib.sessions.serializers.JSONSerializer'
 # A sample logging configuration. The only tangible logging
 # performed by this configuration is to send an email to
 # the site admins on every HTTP 500 error when DEBUG=False.
-# See http://docs.djangoproject.com/en/dev/topics/logging for
+# See https://docs.djangoproject.com/en/dev/topics/logging for
 # more details on how to customize your logging configuration.
 LOGGING = {
     'version': 1,

--- a/example/example/urls.py
+++ b/example/example/urls.py
@@ -12,7 +12,7 @@
 # GNU Lesser General Public License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public License
-# along with this software.  If not, see <http://www.gnu.org/licenses/>.
+# along with this software.  If not, see <https://www.gnu.org/licenses/>.
 
 from django import VERSION
 from django.conf import settings

--- a/example/run_tests.py
+++ b/example/run_tests.py
@@ -14,7 +14,7 @@
 # GNU Lesser General Public License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public License
-# along with this programe.  If not, see <http://www.gnu.org/licenses/>.
+# along with this programe.  If not, see <https://www.gnu.org/licenses/>.
 
 import os
 import sys

--- a/multiselectfield/db/fields.py
+++ b/multiselectfield/db/fields.py
@@ -12,7 +12,7 @@
 # GNU Lesser General Public License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public License
-# along with this programe.  If not, see <http://www.gnu.org/licenses/>.
+# along with this programe.  If not, see <https://www.gnu.org/licenses/>.
 
 from django import VERSION
 from django.db import models

--- a/multiselectfield/forms/fields.py
+++ b/multiselectfield/forms/fields.py
@@ -12,7 +12,7 @@
 # GNU Lesser General Public License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public License
-# along with this programe.  If not, see <http://www.gnu.org/licenses/>.
+# along with this programe.  If not, see <https://www.gnu.org/licenses/>.
 
 from django import forms
 

--- a/multiselectfield/utils.py
+++ b/multiselectfield/utils.py
@@ -12,7 +12,7 @@
 # GNU Lesser General Public License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public License
-# along with this programe.  If not, see <http://www.gnu.org/licenses/>.
+# along with this programe.  If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import annotations
 

--- a/multiselectfield/validators.py
+++ b/multiselectfield/validators.py
@@ -12,7 +12,7 @@
 # GNU Lesser General Public License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public License
-# along with this programe.  If not, see <http://www.gnu.org/licenses/>.
+# along with this programe.  If not, see <https://www.gnu.org/licenses/>.
 
 
 from django.core import validators

--- a/setup.py
+++ b/setup.py
@@ -12,9 +12,9 @@
 # GNU Lesser General Public License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public License
-# along with this programe.  If not, see <http://www.gnu.org/licenses/>.
+# along with this programe.  If not, see <https://www.gnu.org/licenses/>.
 
-# Initial code got from http://djangosnippets.org/users/danielroseman/
+# Initial code got from https://djangosnippets.org/users/danielroseman/
 
 import codecs
 import os

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this programe.  If not, see <https://www.gnu.org/licenses/>.
 
-# Initial code got from https://djangosnippets.org/users/danielroseman/
+# Initial code inspired by https://djangosnippets.org/users/danielroseman/
 
 import codecs
 import os


### PR DESCRIPTION
Just a minor change to use https where relevant. The one exception is the [language link](http://www.i18nguy.com/unicode/language-identifiers.html) in the example project, Django still use this in their docs so it is fine.
Also fixes a minor grammar mistake in setup.py.