### PR TITLE
Change field init so that max_length is not required and get_max_length will be used

### DIFF
--- a/multiselectfield/db/fields.py
+++ b/multiselectfield/db/fields.py
@@ -39,10 +39,12 @@ def add_metaclass(metaclass):
 class MultiSelectField(models.CharField):
     """ Choice values can not contain commas. """
 
-    def __init__(self, *args, **kwargs):
+    # noinspection PyMissingConstructor
+    def __init__(self, *args, db_collation=None, **kwargs):
         self.min_choices = kwargs.pop('min_choices', None)
         self.max_choices = kwargs.pop('max_choices', None)
-        super(MultiSelectField, self).__init__(*args, **kwargs)
+        super(models.CharField).__init__(*args, **kwargs)
+        self.db_collation = db_collation
         self.max_length = get_max_length(self.choices, self.max_length)
         self.validators.append(MaxValueMultiFieldValidator(self.max_length))
         if self.min_choices is not None:


### PR DESCRIPTION
- change __init__ shape to match CharField
- call CharField's parent __init__ to avoid using the CharField MaxLengthValidator