### PR TITLE
Fix KeyError for missing flat_choices in MultiSelectFormField

### DIFF
--- a/example/app/test_msf.py
+++ b/example/app/test_msf.py
@@ -14,10 +14,12 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this software.  If not, see <https://www.gnu.org/licenses/>.
 
+from django import forms
 from django.core.exceptions import ValidationError
 from django.forms.models import modelform_factory
 from django.test import TestCase
 
+from multiselectfield.forms.fields import MultiSelectFormField
 from multiselectfield.utils import get_max_length
 
 from .models import Book, PROVINCES, STATES, PROVINCES_AND_STATES, ONE, TWO
@@ -202,3 +204,20 @@ class MultiSelectUtilsTestCase(TestCase):
             ('key3', 'value3'),
         ]
         self.assertEqual(get_max_length(choices, None), 14)
+
+
+class TestFormWithMultiSelectField(forms.Form):
+    CHOICES = (
+        ('a', 'A'),
+        ('b', 'B'),
+    )
+    reason = MultiSelectFormField(choices=CHOICES, widget=forms.CheckboxSelectMultiple, required=False)
+
+
+class MultiSelectFormFieldTestCase(TestCase):
+    def test_multiselectformfield_without_flat_choices(self):
+        """Test that MultiSelectFormField works when used directly in a Form without flat_choices."""
+        try:
+            TestFormWithMultiSelectField()
+        except KeyError as e:
+            self.fail(f"MultiSelectFormField raised KeyError: {e}")

--- a/multiselectfield/forms/fields.py
+++ b/multiselectfield/forms/fields.py
@@ -27,8 +27,12 @@ class MultiSelectFormField(forms.MultipleChoiceField):
         self.min_choices = kwargs.pop('min_choices', None)
         self.max_choices = kwargs.pop('max_choices', None)
         self.max_length = kwargs.pop('max_length', None)
-        self.flat_choices = kwargs.pop('flat_choices')
+        self.flat_choices = kwargs.pop('flat_choices', None)
         super(MultiSelectFormField, self).__init__(*args, **kwargs)
+
+        if self.flat_choices is None and self.choices:
+            self.flat_choices = self.choices
+
         self.max_length = get_max_length(self.choices, self.max_length)
         self.validators.append(MaxValueMultiFieldValidator(self.max_length))
         if self.max_choices is not None:


### PR DESCRIPTION
This pull request addresses [issue #155](https://github.com/goinnn/django-multiselectfield/issues/155), which raised a KeyError when instantiating a MultiSelectFormField without explicitly providing the flat_choices argument. In some cases, the inherited choices attribute should be sufficient, and requiring flat_choices breaks backwards compatibility with existing code.

Summary of changes:

- Updates the initialization of MultiSelectFormField to avoid raising a KeyError when flat_choices is not provided.
- Falls back to using the choices attribute if flat_choices is not specified.
- Ensures compatibility with forms that do not pass flat_choices explicitly.

Fixes #155