### PR TITLE
Fix broken str method for MSFList when using custom choices

### DIFF
--- a/example/app/test_msf_select.py
+++ b/example/app/test_msf_select.py
@@ -1,4 +1,7 @@
+from django.db import models
 from django.test.testcases import TestCase
+
+from multiselectfield import MultiSelectField
 
 from .models import Book
 
@@ -17,3 +20,25 @@ class MsfSelectTestCase(TestCase):
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0].pk, book.pk)
         self.assertIn(member='1,3,5', container=str(result.query))
+
+
+class MSFListStrTestCase(TestCase):
+    def test_msf_list_str_with_string_choices(self):
+        CHOICE1 = '1'
+        CHOICE2 = '2'
+        CHOICE3 = '3'
+        CHOICE4 = '4'
+        CHOICES = ((CHOICE1, 'A'),
+                   (CHOICE2, 'B'),
+                   (CHOICE3, 'C'),
+                   (CHOICE4, 'D'))
+
+        class TestModel(models.Model):
+            options = MultiSelectField(choices=CHOICES)
+
+        instance = TestModel(options=[CHOICE1, CHOICE2])
+
+        expected = "['1', '2']"
+        actual = str(instance.options)
+
+        self.assertEqual(actual, expected)

--- a/multiselectfield/utils.py
+++ b/multiselectfield/utils.py
@@ -38,11 +38,9 @@ class MSFList(list):
         self.choices = choices
         super(MSFList, self).__init__(*args, **kwargs)
 
-    def __str__(msgl):
-        msg_list = [
-            msgl.choices.get(int(i)) if i.isdigit() else msgl.choices.get(i)
-            for i in msgl]
-        return ', '.join(str(s) for s in msg_list)
+    def __str__(self):
+        msg_list = [self.choices.get(i, i) for i in self]
+        return ', '.join(str(v) for v in msg_list if v is not None)
 
     def resolve_expression(
             self, query: Query = None, allow_joins: bool = True,


### PR DESCRIPTION
This pull request resolves [issue #76](https://github.com/goinnn/django-multiselectfield/issues/76), where the str method of MSFList returns None values when choices are custom-defined as tuples. The issue occurred because the method did not properly retrieve display values for the selected choices.

- Updates the str implementation of MSFList to correctly map selected values to their display labels, ensuring that string representations of MSFList instances are accurate and user-friendly.
- The new implementation iterates over the available choices and includes only those present in the current MSFList, avoiding None values in the output.

Fixes #76